### PR TITLE
feat: be able to choose how an image is loaded

### DIFF
--- a/images/layouts/partials/image.html
+++ b/images/layouts/partials/image.html
@@ -4,6 +4,7 @@
 {{ $size:= .Size }}
 {{ $resize:= .Resize | default true}}
 {{ $alt:= .Alt }}
+{{ $loading:= .Loading | default "lazy" }}
 {{ $context:= .Context | default . }}
 {{ $contentImage:= false }}
 {{ $assetImage:= false }}
@@ -32,7 +33,7 @@
 
 <!-- image static/CDN -->
 {{ if or (hasPrefix $imagePath "http") (fileExists (add `static/` (string $imagePath))) }}
-<img loading="lazy" decoding="async" src="{{ $imagePath | absURL }}" alt="{{.Alt}}" class="{{$class}} img-fluid" height="{{$height}}" width="{{$width}}">
+<img loading="{{.Loading}}" decoding="async" src="{{ $imagePath | absURL }}" alt="{{.Alt}}" class="{{$class}} img-fluid" height="{{$height}}" width="{{$width}}">
 {{ else }}
 <!-- /image cdn -->
 


### PR DESCRIPTION
# Possibility to override loading type for images

After running the [Google Pagespeed Tool](https://pagespeed.web.dev/) on my Hugo website, it gives me a warning that the "Largest Contentful Paint image was lazily loaded". This is the case when this concerns an image directly into the viewport.

To solve this, you should be able to choose whether the image is lazy loaded or not. This PR looks to resolve that issue.


![Screenshot 2023-03-14 at 22 31 03](https://user-images.githubusercontent.com/7848606/225141765-2f82c0a3-1c4a-454d-acad-2f805351d1f4.png)
