### PR TITLE
Improve Logo Aspect Ratio Consistency

### DIFF
--- a/images/layouts/partials/logo.html
+++ b/images/layouts/partials/logo.html
@@ -4,7 +4,7 @@
 {{ $logoText:= site.Params.logo_text }}
 {{ $logoWidth:= add (replace site.Params.logo_width "px" "") "x" }}
 {{ $logoDefaultWidth:= site.Params.logo_width }}
-{{ $logoDefaultHeight:= "" }}
+{{ $logoDefaultHeight:= "auto" }}
 {{ $context:= . }}
 {{ $assetImage:= false }}
 {{ $scratch := newScratch }}


### PR DESCRIPTION
This pull request addresses an issue frequently encountered with PageSpeed Insights, where the aspect ratio of the logo is flagged as inconsistent due to the resizing of the width without a corresponding adjustment to the height. The proposed changes ensure that both dimensions are properly scaled. Its not tested since its only a small fix