### PR TITLE
Add image context in search module

### DIFF
--- a/search/layouts/_default/list.searchindex.json
+++ b/search/layouts/_default/list.searchindex.json
@@ -18,12 +18,12 @@
 {{- $date:= time.Format ":date_long" .PublishDate -}}
 
 {{- if .Params.image -}}
-  {{- $.Scratch.Set "image" (partial "searchImage" (dict "Src" .Params.image "Size" "420x" "Command" "Resize")) -}}
-  {{- $.Scratch.Set "imageSM" (partial "searchImage" (dict "Src" .Params.image "Size" "100x100" "Command" "Fill")) -}}
+  {{- $.Scratch.Set "image" (partial "searchImage" (dict "Context" .Page "Src" .Params.image "Size" "420x" "Command" "Resize")) -}}
+  {{- $.Scratch.Set "imageSM" (partial "searchImage" (dict "Context" .Page "Src" .Params.image "Size" "100x100" "Command" "Fill")) -}}
 {{- else if .Params.images -}}
   {{- range first 1 .Params.images -}}
-  {{- $.Scratch.Set "image" (partial "searchImage" (dict "Src" . "Size" "420x" "Command" "Resize")) -}}
-  {{- $.Scratch.Set "imageSM" (partial "searchImage" (dict "Src" . "Size" "100x100" "Command" "Fill")) -}}
+  {{- $.Scratch.Set "image" (partial "searchImage" (dict "Context" .Page "Src" . "Size" "420x" "Command" "Resize")) -}}
+  {{- $.Scratch.Set "imageSM" (partial "searchImage" (dict "Context" .Page "Src" . "Size" "100x100" "Command" "Fill")) -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Search module only displays images with absolute URLs, the context is not sent to the `searchImage` partial so it uses the default "dot". This PR adds the `.Page` context to the partial.

Issue: https://github.com/gethugothemes/hugo-modules/issues/19
