### PR TITLE
Remove global regex in search modal

### DIFF
--- a/search/assets/js/search.js
+++ b/search/assets/js/search.js
@@ -217,11 +217,11 @@ if (hasSearchWrapper) {
         });
 
       const highlightResult = (content) => {
-        const regex = new RegExp(searchString, "gi");
+        const regex = new RegExp(searchString, "i");
         return content.replace(regex, (match) => `<u>${match}</u>`);
       };
       const highlightResultContent = (content) => {
-        const regex = new RegExp(searchString, "gi");
+        const regex = new RegExp(searchString, "i");
         const matchIndex = content.search(regex);
 
         if (matchIndex >= 0) {
@@ -229,7 +229,7 @@ if (hasSearchWrapper) {
           const lastWord = content.slice(0, matchIndex).split(" ").pop();
 
           return matchedContent.replace(
-            new RegExp(searchString, "i"),
+            regex,
             (match) => lastWord + `<mark>${match}</mark>`
           );
         }

--- a/search/assets/js/search.js
+++ b/search/assets/js/search.js
@@ -229,7 +229,7 @@ if (hasSearchWrapper) {
           const lastWord = content.slice(0, matchIndex).split(" ").pop();
 
           return matchedContent.replace(
-            regex,
+            new RegExp(searchString, "i"),
             (match) => lastWord + `<mark>${match}</mark>`
           );
         }


### PR DESCRIPTION
This PR attempts to solve issue https://github.com/gethugothemes/hugo-modules/issues/20

When the search string has several matches inside the same post, the excerpt displayed repeats the prefix from the first matching word. This PR removes the global flag from the search regex to highlight only the first occurrence, as finding a single occurrence should be enough in the context of this module.
