### PR TITLE
Bugfix in image-pipe

### DIFF
--- a/gallery-slider/layouts/partials/image-pipe.html
+++ b/gallery-slider/layouts/partials/image-pipe.html
@@ -34,10 +34,18 @@
 
 
     <!-- if webp false -->
-    {{ if or (eq $webp "false") (eq $webp false) }}
-      {{ $option = add (add (add (add (string ($width | default $imageWidth)) "x") (string ($height | default $imageHeight))) " ") (string $option) }}
+    {{ if or ($width) ($height) }}
+    <!-- If either Width or Height is set, construct $option without default values -->
+    {{ $option = add (add (string $width) "x" (string $height)) " " }}
     {{ else }}
-      {{ $option = add (add (add (add (string ($width | default $imageWidth)) "x") (string ($height | default $imageHeight))) " webp ") (string $option) }}
+    <!-- Original logic if neither Width nor Height is set -->
+    {{ $option = add (add (add (add (string ($width | default $imageWidth)) "x") (string ($height | default $imageHeight)))
+    " ") (string $option) }}
+    {{ end }}
+    
+    <!-- Add "webp" if necessary -->
+    {{ if or (eq $webp "false") (eq $webp false) }}
+    {{ $option = add $option "webp " }}
     {{ end }}
 
 


### PR DESCRIPTION
Fix problem where provided Height or Width was ignored.

I ran into this problem as I was loading extremely large images and they wouldn't be resized correctly when providing either Height or Width.