### PR TITLE
Fix typos and update images/readme

### DIFF
--- a/accordion/README.md
+++ b/accordion/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/accordion"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'accordion';

--- a/components/preloader/README.md
+++ b/components/preloader/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/components/preloader"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'preloader';

--- a/components/social-share/README.md
+++ b/components/social-share/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/components/social-share"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'social-share';

--- a/gallery-slider/README.md
+++ b/gallery-slider/README.md
@@ -26,7 +26,7 @@ link = "plugins/glightbox/glightbox.js"
 link = "js/gallery-slider.js"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'gallery-slider';

--- a/images/README.md
+++ b/images/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/images"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'images';

--- a/images/README.md
+++ b/images/README.md
@@ -38,8 +38,9 @@ Define the logo in the `config/_default/params.toml` file.
 ```toml
 # logo
 logo = "images/logo.png"
-# logo_dark only used when theme has a dark mode
-logo_dark = "images/logo_darkmode.png"
+
+# logo_darkmode only used when theme has a dark mode
+logo_darkmode = "images/logo_darkmode.png"
 
 # use `px` or `x` with logo_width, example: "100px".
 # Note: logo_width is not work with .svg file

--- a/modal/README.md
+++ b/modal/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/modal"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'modal';

--- a/shortcodes/collapse/README.md
+++ b/shortcodes/collapse/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/shortcodes/collapse"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'collapse';

--- a/shortcodes/gallery/README.md
+++ b/shortcodes/gallery/README.md
@@ -18,7 +18,7 @@ Add the following code to your js plugins list in the `config.toml` file.
 link = "plugins/glightbox.js"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'gallery';

--- a/shortcodes/notice/README.md
+++ b/shortcodes/notice/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/shortcodes/notice"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'notice';

--- a/shortcodes/table-of-contents/README.md
+++ b/shortcodes/table-of-contents/README.md
@@ -11,7 +11,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/shortcodes/table-of-contents"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'toc';

--- a/shortcodes/tabs/README.md
+++ b/shortcodes/tabs/README.md
@@ -11,7 +11,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/shortcodes/tabs"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'tabs';

--- a/tab/README.md
+++ b/tab/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/tab"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'tab';

--- a/table-of-contents/README.md
+++ b/table-of-contents/README.md
@@ -9,7 +9,7 @@ Add the following code to your module list in the `config/_default/module.toml` 
 path = "github.com/gethugothemes/hugo-modules/table-of-contents"
 ```
 
-Add the following code to your `asstes/scss/main.scss` or `asstes/scss/style.scss` file.
+Add the following code to your `assets/scss/main.scss` or `assets/scss/style.scss` file.
 
 ```scss
 @import 'toc';


### PR DESCRIPTION
This PR:

- Fixes `asstes` typo and replaces it with `assets`.
- Replaces `logo_dark` with `logo_darkmode' as that's the correct attribute name.