### PR TITLE
Fix tabs group issue: tabs of the same group not switching together

### DIFF
--- a/tab/assets/js/tab.js
+++ b/tab/assets/js/tab.js
@@ -5,10 +5,7 @@
   const tabGroups = document.querySelectorAll("[data-tab-group]");
   const tablist = document.querySelectorAll("[data-tab-nav] [data-tab]");
 
-  function setActiveTab(tabGroup, tabName) {
-    const tabsNav = tabGroup.querySelector("[data-tab-nav]");
-    const tabsContent = tabGroup.querySelector("[data-tab-content]");
-
+  function activate(tabsNav, tabsContent, tabName) {
     tabsNav.querySelectorAll("[data-tab]").forEach((tabNavItem) => {
       tabNavItem.classList.remove("active");
     });
@@ -22,6 +19,27 @@
       `[data-tab-panel="${tabName}"]`
     );
     selectedTabPane.classList.add("active");
+  }
+
+  function setActiveTab(tabGroup, tabName) {
+    if (!tabGroup.dataset.tabGroup) {
+      // tabs group name is falsy, process as an independent tabs group
+      const tabsNav = tabGroup.querySelector("[data-tab-nav]");
+      const tabsContent = tabGroup.querySelector("[data-tab-content]");
+      activate(tabsNav, tabsContent, tabName);
+    } else {
+      // Select for all tabs groups with the same non-falsy group name
+      const tabsNavAll = document.querySelectorAll(`[data-tab-group=${tabGroup.dataset.tabGroup}] > [data-tab-nav]`);
+      const tabsContentAll = document.querySelectorAll(`[data-tab-group=${tabGroup.dataset.tabGroup}] > [data-tab-content]`);
+
+      tabsNavAll.forEach((tabsNav, index) => {
+        const tabsContent = tabsContentAll[index];
+        if (tabsContent === undefined) {
+          return;
+        }
+        activate(tabsNav, tabsContent, tabName);
+      });
+    }
   }
 
   tabGroups.forEach((tabGroup) => {

--- a/tab/layouts/shortcodes/tabs.html
+++ b/tab/layouts/shortcodes/tabs.html
@@ -1,5 +1,5 @@
 {{ with .Inner }}{{/* don't do anything, just call it */}}{{ end }}
-{{ $groupId := default "default" (.Get 0) }}
+{{ $groupId := default "" (.Get 0) }}
 
 <div class="tab" data-tab-group="{{ $groupId }}">
   <ul class="tab-nav" data-tab-nav>


### PR DESCRIPTION
Allow for tabs with the same group name to be changed simultaneously.

When the tab group is not specified, treat the tabs independently w.r.t all other tabs. That is, do not change the tab with missing/empty tabgroup when any other tabs are changed, nor  change any other tabs when the former is changed.

This fixed https://github.com/gethugothemes/hugo-modules/issues/36