### PR TITLE
Fix impossible to load Hugo module announcements

### DIFF
--- a/components/announcement/go.mod
+++ b/components/announcement/go.mod
@@ -1,3 +1,3 @@
 module github.com/gethugothemes/hugo-modules/components/announcement
 
-go 1.20.0
+go 1.20


### PR DESCRIPTION
Hi,

I'm unable to launch a fresh build with this project

```
go: downloading github.com/gethugothemes/hugo-modules v0.0.0-20240504032439-79fc09d96848
go: github.com/gethugothemes/hugo-modules/components/announcement upgrade => v0.0.0-20240504032439-79fc09d96848
go get: github.com/gethugothemes/hugo-modules/components/announcement@v0.0.0-20240504032439-79fc09d96848: parsing go.mod: go.mod:3: invalid go version '1.20.0': must match format 1.23
```

It seems the version check is wrong here, could you merge this change?

```
$ go version
go version go1.15.6 darwin/amd64

$ hugo version
hugo v0.126.1+extended darwin/amd64 BuildDate=2024-05-15T10:42:34Z VendorInfo=brew
```

Thanks!