### PR TITLE
remove added extra space between links and following punctuation

### DIFF
--- a/components/render-link/layouts/_default/_markup/render-link.html
+++ b/components/render-link/layouts/_default/_markup/render-link.html
@@ -15,3 +15,4 @@
  class="{{$class}}"
 {{ end }}
 >{{.Text | safeHTML}}</a>
+{{- /* This comment removes trailing newlines. */ -}}


### PR DESCRIPTION
This PR solve the issue where an extra white space is added between links and text that directly follows it.
see https://discourse.gohugo.io/t/white-space-issue-in-markdown/25258