### PR TITLE
Optionally add sectionpages to search-index

### DIFF
--- a/search/README.md
+++ b/search/README.md
@@ -58,6 +58,7 @@ enable = true
 primary_color = "#ce8460"
 include_sections = ["post", "shop"] # if `include_sections` empty, then sections will come from the `mainSections`
 include_all_sections = false # if `include_all_sections` is true, then comment out the `include_sections`
+include_section_pages = true
 show_image = true
 show_description = true
 show_tags = true

--- a/search/layouts/_default/list.searchindex.json
+++ b/search/layouts/_default/list.searchindex.json
@@ -10,9 +10,14 @@
 {{- $search_sections = site.Params.search.include_sections | default site.Params.mainSections -}}
 {{- end -}}
 
-{{- $totalPagesLength := len (where site.RegularPages "Section" "in" $search_sections) -}}
+{{- $searchablePages := (where site.RegularPages "Section" "in" $search_sections) -}}
+{{- if site.Params.search.include_section_pages -}}
+{{- $searchablePages = (where site.Pages "Section" "in" $search_sections) -}}
+{{- end -}}
 
-[{{- range $i, $e := (where site.RegularPages "Section" "in" $search_sections) -}}
+{{- $totalPagesLength := len $searchablePages -}}
+
+[{{- range $i, $e := $searchablePages -}}
 {{- if not .Params.ignoreSearch -}}
 
 {{- $date:= time.Format ":date_long" .PublishDate -}}


### PR DESCRIPTION
This PR addresses the following issue:

On our website we have a structure like:

├── tropic-1
│   ├── detailed_article-1.1
│   └── detailed_article-1.2
├── topic-2
...

We have content the regular pages (leave nodes) and the section pages (inner nodes).
The search-index build by the search module only collects the regular pages and not the section pages.
This makes the section-pages unsearchable.

This PR solves this by also collecting the section pages if the `search.include_section_pages` param is set.