### PR TITLE
fix: use correct src url with path in baseURL

### DIFF
--- a/videos/layouts/shortcodes/video.html
+++ b/videos/layouts/shortcodes/video.html
@@ -19,7 +19,7 @@
 
   <!-- checking content/static -->
 {{ else }}
-  {{ .Scratch.Set "video_path" (print "/" $videoPath) }}
+  {{ .Scratch.Set "video_path" (relURL $videoPath) }}
 {{ end }}
 
 {{ $videoPath = .Scratch.Get "video_path" }}


### PR DESCRIPTION
The src url generated by the video shortcode must not assume that the hugo baseURL is the root of the site.

This patch uses relURL to ensure correct src urls in cases where the hugo baseURL contains a path, e.g., "https://example.com/some/path/"