### PR TITLE
image-shortcode: Print warning if file not found

### DIFF
--- a/images/layouts/shortcodes/image.html
+++ b/images/layouts/shortcodes/image.html
@@ -190,6 +190,7 @@
 
   {{ else }}
     <!-- image not found -->
+    {{ warnf "Image file not found: %s (referenced by %s)" $imagePath .Page.File.Path }}
     <strong style="color:red; margin-bottom:15px; display:inline-block;"
       >{{ site.BaseURL }}{{ $imagePath }} does not exist</strong
     >


### PR DESCRIPTION
If a referenced image path does not exist, print a warning to the console (but do not exit). This helps to identify missing images on build time, and could be used in, e.g., CI/CD pipelines to fail the build.

For the image shortcode, this is already pretty easy to do because there are already all required checks implemented in the current implementation.  
(For the video shortcode I will open a PR soon, but there I need to add some checks using resources.Get and fileExists)