### PR TITLE
basic-seo: Fallback to site param for noindex if page param is not set

### DIFF
--- a/seo-tools/basic-seo/layouts/partials/basic-seo.html
+++ b/seo-tools/basic-seo/layouts/partials/basic-seo.html
@@ -18,7 +18,7 @@
 <title>{{ $title }}</title>
 
 <!-- meta noindex -->
-{{ if .Params.noindex }}
+{{ if .Param "noindex" }}
   <meta name="robots" content="noindex,nofollow" />
 {{ end }}
 


### PR DESCRIPTION
This allows to set noindex globally in config.toml instead of copying it manually to every page.

See https://gohugo.io/methods/page/param/