### PR TITLE
Add custom title to notice

### DIFF
--- a/shortcodes/notice/layouts/shortcodes/notice.html
+++ b/shortcodes/notice/layouts/shortcodes/notice.html
@@ -1,7 +1,9 @@
 {{ $type:= .Get 0 }}
+{{ $title := "" }}
 
 {{ range $i, $e:= .Params }}
   {{ if eq $i "type" }}{{ $type = $e }}{{ end }}
+  {{ if eq $i "title" }}{{ $title = $e }}{{ end }}
 {{ end }}
 
 {{ $type_class := "info" }}
@@ -105,7 +107,11 @@
           stroke-linejoin="round"></path>
       </svg>
     {{- end -}}
-    <p>{{ $type | title }}</p>
+    {{ if $title }}
+      <p>{{ $title }}</p>
+    {{ else }}
+      <p>{{ $type | title }}</p>
+    {{ end }}
   </div>
   <div class="notice-body"><p>{{ .Inner | markdownify }}</p></div>
 </div>


### PR DESCRIPTION
Hi,

Great work on the repo :)

I have been trying to use notice shorthand in my project, but as far as I can see there's no way to actually translate/provide own title, even though discussion in issue #73 indicated otherwise.

I have modified the code and thought I'd share. If I'm wrong and the shorthand allows custom title **with** being able to select a variant, feel free to disregard this PR.