### PR TITLE
Add default author for Twitter metadata

### DIFF
--- a/seo-tools/basic-seo/layouts/partials/basic-seo.html
+++ b/seo-tools/basic-seo/layouts/partials/basic-seo.html
@@ -163,6 +163,7 @@
 {{ with site.Params.metadata.twitter }}
   <meta name="twitter:site" content="@{{ . }}" />
 {{ end }}
-{{ with site.Params.metadata.author }}
+{{ $twitterAuthor := site.Params.metadata.twitter_author | default site.Params.metadata.author }}
+{{ with $author }}
   <meta name="twitter:creator" content="@{{ . }}" />
 {{ end }}


### PR DESCRIPTION
Add the possibility to specify the twitter author in `[metadata]`