### PR TITLE
Prefix the manifest URL with the language

### DIFF
--- a/pwa/layouts/partials/manifest.html
+++ b/pwa/layouts/partials/manifest.html
@@ -1,5 +1,5 @@
 <!-- web manifest -->
-<link rel="manifest" href="{{ `manifest.webmanifest` | relURL }}" />
+<link rel="manifest" href="{{ `manifest.webmanifest` | relLangURL }}" />
 <meta
   name="msapplication-TileColor"
   content="{{ site.Params.variables.color_primary | default `#ddd` }}" />


### PR DESCRIPTION
In a multilingual website, prefixing the manifest's relative URL with the language is necessary for the manifest to work. 

Without it, a language-agnostic
```
<link rel="manifest" href="/manifest.webmanifest" />
```
is generated, resulting in 404, while with it, elements such as
```
<link rel="manifest" href="/en/manifest.webmanifest" />
```
or
```
<link rel="manifest" href="/pt/manifest.webmanifest" />
```
are generated within corresponding language-aware pages, allowing manifests to be successfully fetched.